### PR TITLE
This commit fixes the persistent `ModuleNotFoundError` by updating th…

### DIFF
--- a/protokollfuehrer-agent/Dockerfile
+++ b/protokollfuehrer-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.9-slim
+FROM python:3.9-buster
 
 # Set the working directory in the container
 WORKDIR /app


### PR DESCRIPTION
…e Docker base image from `python:3.9-slim` to `python:3.9-buster`.

The `-slim` image lacked the necessary system-level dependencies (e.g., `gcc`) required to compile the native extensions for Python packages like `psycopg2-binary`, causing the installation to fail silently during the Docker build. The `-buster` image includes these build tools, ensuring that all dependencies listed in `requirements.txt` are installed correctly.

This change provides a robust and functional containerized environment for the Protokollführer RAG assistant.